### PR TITLE
Filter password in connstr before logging it

### DIFF
--- a/python/skytools/scripting.py
+++ b/python/skytools/scripting.py
@@ -3,7 +3,7 @@
 
 """
 
-import sys, os, signal, optparse, time, errno, select
+import sys, os, signal, optparse, time, errno, select, re
 import logging, logging.handlers, logging.config
 
 import skytools
@@ -712,7 +712,9 @@ class DBScript(BaseScript):
         else:
             if not connstr:
                 connstr = self.cf.get(dbname)
-            self.log.debug("Connect '%s' to '%s'" % (cache, connstr))
+            # connstr might contain password, it is not a good idea to log it
+            filtered_connstr = re.sub(' password=\S+', ' password=***HIDDEN***', connstr)
+            self.log.debug("Connect '%s' to '%s'" % (cache, filtered_connstr))
             dbc = DBCachedConn(cache, connstr, params['max_age'], setup_func = self.connection_hook)
             self.db_cache[cache] = dbc
 


### PR DESCRIPTION
python/skytools/scripting.py logs full connstr on debug level, but there might be password inside this connstr. This change will filter the password before logging, so it wont leak out. (think environments that replicate logs out of the box running skytools)
