### PR TITLE
Allow for building with different python versions

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -35,8 +35,8 @@ FQMAN = $(FQMAN1) $(FQMAN1_SFX) $(FQMAN5)
 
 COMMON = common.switches.txt common.config.txt
 
-GETATTRS = python ../misc/getattrs.py
-FIXMAN = python ../misc/fixman.py
+GETATTRS = $(PYTHON) ../misc/getattrs.py
+FIXMAN = $(PYTHON) ../misc/fixman.py
 
 #AFLAGS = -a linkcss
 #AFLAGS = -a stylesheet=extra.css

--- a/sql/Makefile
+++ b/sql/Makefile
@@ -9,6 +9,7 @@ all install clean distclean installcheck test:
 		DESTDIR="$(DESTDIR)" \
 		PG_CONFIG="$(PG_CONFIG)" \
 		PG_CPPFLAGS="$(PG_CPPFLAGS)" \
+		PYTHON="$(PYTHON)" \
 	  || exit $?; \
 	done
 

--- a/sql/common-pgxs.mk
+++ b/sql/common-pgxs.mk
@@ -64,8 +64,8 @@ include $(PGXS)
 
 NDOC = NaturalDocs
 NDOCARGS = -r -o html docs/html -p docs -i docs/sql
-CATSQL = ../../scripts/catsql.py
-GRANTFU = ../../scripts/grantfu.py
+CATSQL = $(PYTHON) ../../scripts/catsql.py
+GRANTFU = $(PYTHON) ../../scripts/grantfu.py
 
 #
 # build rules, in case Contrib data must be always installed

--- a/upgrade/Makefile
+++ b/upgrade/Makefile
@@ -6,7 +6,7 @@ SQLS = v3.0_pgq_core.sql
 SRCS = $(addprefix src/, $(SQLS))
 DSTS = $(addprefix final/, $(SQLS))
 
-CATSQL = python ../scripts/catsql.py
+CATSQL = $(PYTHON) ../scripts/catsql.py
 
 all: $(DSTS)
 


### PR DESCRIPTION
Hi Marko,

Here is a simple fix for building with different Python versions. This allows for using the './configure --with-python=PYTHON" flag to use a specific version of Python (not whatever `python` points to).

Oh and I'm also playing around with github. ;)

Cheers,

 Emiel
