### PR TITLE
Only setting PG_CONFIG if it hasn't already been set.

### DIFF
--- a/sql/pgq/lowlevel/Makefile
+++ b/sql/pgq/lowlevel/Makefile
@@ -5,7 +5,7 @@ DATA = pgq_lowlevel.sql
 SRCS = insert_event.c
 OBJS = $(SRCS:.c=.o)
 
-PG_CONFIG = pg_config
+PG_CONFIG ?= pg_config
 PGXS = $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 


### PR DESCRIPTION
My machine has two different copies of libpg installed on it. Specifying PG_CONFIG
should encourage the build to use the value of that for calling pg_config.
