### PR TITLE
londiste3 add-table option --copy-condition removed from man page

### DIFF
--- a/doc/londiste3.txt
+++ b/doc/londiste3.txt
@@ -305,9 +305,6 @@ Do full copy of the table, again.
     Useful if provider does not contain table data locally
     or is simply under load.
 
-  --copy-condition='copy_condition'::
-    Set WHERE expression for copy.
-
   --merge-all::
     Merge tables from all source queues.
 


### PR DESCRIPTION
This option is no longer available as londiste3 add-table option.
Removed in ccfcf87df7fe0a123b563efec1639dec8367c2da
