### PR TITLE
Fix execute skip

### DIFF
--- a/python/londiste/playback.py
+++ b/python/londiste/playback.py
@@ -726,7 +726,7 @@ class Replicator(CascadedWorker):
         res = self.exec_cmd(dst_curs, q, [self.queue_name, fname, sql, s_attrs], commit = False)
         ret = res[0]['ret_code']
         if ret > 200:
-            self.log.info("Skipping execution of '%s'", fname)
+            self.log.warning("Skipping execution of '%s'", fname)
             if pgver >= 80300:
                 dst_curs.execute("set local session_replication_role = 'replica'")
             return

--- a/python/londiste/setup.py
+++ b/python/londiste/setup.py
@@ -572,7 +572,7 @@ class LondisteSetup(CascadeAdmin):
             q = "select * from londiste.execute_start(%s, %s, %s, true, %s)"
             res = self.exec_cmd(db, q, [self.queue_name, fname, sql, attrs.to_urlenc()], commit = False)
             ret = res[0]['ret_code']
-            if ret >= 300:
+            if ret > 200:
                 self.log.warning("Skipping execution of '%s'", fname)
                 continue
             if attrs.need_execute(curs, local_tables, local_seqs):


### PR DESCRIPTION
Consider script.sql that has been executed on root and branch by means of `londiste3 root-config.ini execute script.sql`. Subsequent attempts display a warning and execute script.sql on root anyway as follows.

``` bash
ruslan@root-host$ londiste3 root-config.ini script.sql
2014-07-16 20:46:44,739 6240 INFO EXECUTE: "script.sql" already applied, skipping
2014-07-16 20:46:44,740 6240 INFO script.sql: executing sql
(more output related to execution of script.sql)
```

This pull request corrects the previous behaviour as follows.

``` bash
ruslan@root-host$ londiste3 root-config.ini script.sql
2014-07-16 21:14:44,815 30432 INFO EXECUTE: "script.sql" already applied, skipping
2014-07-16 21:14:44,815 30432 WARNING Skipping execution of 'script.sql'
```
