### PR TITLE
Build pkgloader as part of "make all"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ sub-all sub-install sub-clean sub-distclean:
 .PHONY: sub-all sub-clean sub-install sub-distclean
 
 python-all: config.mak
+	$(PYTHON) setup_pkgloader.py build
 	$(PYTHON) setup_skytools.py build
 
 clean: sub-clean


### PR DESCRIPTION
pkgloader was not built as part of "make all", only indirectly as part
of "make install".  As a result, if one runs "sudo make install", the
"build" subdirectory of the source tree becomes owned by root, which can
lead to annoyance.  Therefore, build pkgloader during "make all",
similar to the skytools package.
