### PR TITLE
Fix TCP_KEEPALIVE on Darwin

### DIFF
--- a/python/skytools/sockutil.py
+++ b/python/skytools/sockutil.py
@@ -63,7 +63,7 @@ def set_tcp_keepalive(fd, keepalive = True,
     TCP_KEEPALIVE = getattr(socket, 'TCP_KEEPALIVE', None)
     SIO_KEEPALIVE_VALS = getattr(socket, 'SIO_KEEPALIVE_VALS', None)
     if TCP_KEEPIDLE is None and TCP_KEEPALIVE is None and sys.platform == 'darwin':
-        TCP_KEEPALIVE = 0x10
+        TCP_KEEPALIVE = 0x08
 
     # configure
     if TCP_KEEPCNT is not None:


### PR DESCRIPTION
This patch corrects a bad magic number used to set the socket option
TCP_KEEPALIVE on Darwin hosts when Python does not provide a definition
of its own (e.g. Python v2.7.10)

On Darwin 10.11, the mappings in <sys/socket.h> for the incorrect
magic value (0x10) and TCP_KEEPALIVE are as follows::

```
#define SO_KEEPALIVE    0x0008      /* keep connections alive */
#define SO_DONTROUTE    0x0010      /* just use interface addresses */
```

So the value has been changed from 0x10 -> 0x08, and this has resolved
issues experienced with unconnected listening sockets (error: [Errno 60]
Operation timed out)

.. [1] Source available at
http://www.opensource.apple.com/source/xnu/xnu-3247.1.106/bsd/sys/socket.h XNU-3247.1.106 corresponds to Darwin 10.11 (according to http://www.opensource.apple.com/release/os-x-1011/)
