### PR TITLE
9.5: Fix \set ECHO to use none instead of off

### DIFF
--- a/sql/londiste/expected/init_ext.out
+++ b/sql/londiste/expected/init_ext.out
@@ -1,4 +1,4 @@
-\set ECHO off
+\set ECHO none
  upgrade_schema 
 ----------------
               0

--- a/sql/londiste/expected/init_ext_1.out
+++ b/sql/londiste/expected/init_ext_1.out
@@ -1,4 +1,4 @@
-\set ECHO off
+\set ECHO none
  upgrade_schema 
 ----------------
               2

--- a/sql/londiste/expected/init_noext.out
+++ b/sql/londiste/expected/init_noext.out
@@ -1,4 +1,4 @@
-\set ECHO off
+\set ECHO none
  upgrade_schema 
 ----------------
               0

--- a/sql/londiste/expected/init_noext_1.out
+++ b/sql/londiste/expected/init_noext_1.out
@@ -1,4 +1,4 @@
-\set ECHO off
+\set ECHO none
  upgrade_schema 
 ----------------
               0

--- a/sql/londiste/expected/londiste_install.out
+++ b/sql/londiste/expected/londiste_install.out
@@ -1,4 +1,4 @@
-\set ECHO off
+\set ECHO none
  upgrade_schema 
 ----------------
               0

--- a/sql/londiste/expected/londiste_merge.out
+++ b/sql/londiste/expected/londiste_merge.out
@@ -253,7 +253,7 @@ select * from londiste.global_add_table('part3_set', 'tblmerge');
       200 | Table added: tblmerge
 (1 row)
 
-\set ECHO off
+\set ECHO none
 select * from testmatrix();
      p1s      |     p2s      |     p3s      |     p1r     |     p2r     |     p3r     
 --------------+--------------+--------------+-------------+-------------+-------------

--- a/sql/londiste/sql/init_ext.sql
+++ b/sql/londiste/sql/init_ext.sql
@@ -1,4 +1,4 @@
-\set ECHO off
+\set ECHO none
 
 set log_error_verbosity = 'terse';
 set client_min_messages = 'fatal';

--- a/sql/londiste/sql/init_noext.sql
+++ b/sql/londiste/sql/init_noext.sql
@@ -1,4 +1,4 @@
-\set ECHO off
+\set ECHO none
 
 set log_error_verbosity = 'terse';
 set client_min_messages = 'fatal';

--- a/sql/londiste/sql/londiste_install.sql
+++ b/sql/londiste/sql/londiste_install.sql
@@ -1,4 +1,4 @@
-\set ECHO off
+\set ECHO none
 
 set log_error_verbosity = 'terse';
 set client_min_messages = 'fatal';

--- a/sql/londiste/sql/londiste_merge.sql
+++ b/sql/londiste/sql/londiste_merge.sql
@@ -70,7 +70,7 @@ select * from londiste.get_table_list('combined_set');
 
 select * from londiste.global_add_table('part3_set', 'tblmerge');
 
-\set ECHO off
+\set ECHO none
 
 create table states ( state text );
 insert into states values ('in-copy');

--- a/sql/pgq/expected/pgq_perms.out
+++ b/sql/pgq/expected/pgq_perms.out
@@ -1,4 +1,4 @@
-\set ECHO off
+\set ECHO none
 drop role if exists pgq_test_producer;
 drop role if exists pgq_test_consumer;
 drop role if exists pgq_test_admin;

--- a/sql/pgq/sql/pgq_perms.sql
+++ b/sql/pgq/sql/pgq_perms.sql
@@ -1,4 +1,4 @@
-\set ECHO off
+\set ECHO none
 \set VERBOSITY 'terse'
 set client_min_messages = 'warning';
 

--- a/sql/pgq_ext/expected/init_ext.out
+++ b/sql/pgq_ext/expected/init_ext.out
@@ -1,4 +1,4 @@
-\set ECHO off
+\set ECHO none
  upgrade_schema 
 ----------------
               4

--- a/sql/pgq_ext/expected/init_noext.out
+++ b/sql/pgq_ext/expected/init_noext.out
@@ -1,4 +1,4 @@
-\set ECHO off
+\set ECHO none
  upgrade_schema 
 ----------------
               4

--- a/sql/pgq_ext/expected/test_upgrade.out
+++ b/sql/pgq_ext/expected/test_upgrade.out
@@ -1,4 +1,4 @@
-\set ECHO off
+\set ECHO none
  upgrade_schema 
 ----------------
               8

--- a/sql/pgq_ext/sql/init_ext.sql
+++ b/sql/pgq_ext/sql/init_ext.sql
@@ -1,5 +1,5 @@
 
-\set ECHO off
+\set ECHO none
 \i structure/install.sql
 \set ECHO all
 create extension pgq_ext from 'unpackaged';

--- a/sql/pgq_ext/sql/init_noext.sql
+++ b/sql/pgq_ext/sql/init_noext.sql
@@ -1,3 +1,3 @@
-\set ECHO off
+\set ECHO none
 \i structure/install.sql
 

--- a/sql/pgq_ext/sql/test_upgrade.sql
+++ b/sql/pgq_ext/sql/test_upgrade.sql
@@ -1,5 +1,5 @@
 
-\set ECHO off
+\set ECHO none
 
 set log_error_verbosity = 'terse';
 set client_min_messages = 'fatal';


### PR DESCRIPTION
This is throwing warnings otherwise that break the regression tests in
9.5+.
