### PR TITLE
Fix branch-leaf repair

### DIFF
--- a/python/londiste/syncer.py
+++ b/python/londiste/syncer.py
@@ -325,7 +325,7 @@ class Syncer(skytools.DBScript):
             q = "select * from pgq_node.get_node_info(%s)"
             res = self.exec_cmd(dst_db, q, [self.queue_name])
             last_tick = res[0]['worker_last_tick']
-            if last_tick > tick_id:
+            if last_tick >= tick_id:
                 break
 
             # limit lock time

--- a/tests/env.sh
+++ b/tests/env.sh
@@ -18,4 +18,5 @@ export PYTHONPATH PATH LD_LIBRARY_PATH PATH
 PGHOST=localhost
 export PGHOST
 
-
+# to make tests independent from user environment
+PSQLRC=/dev/null

--- a/tests/londiste/test-compare.sh
+++ b/tests/londiste/test-compare.sh
@@ -60,7 +60,7 @@ run londiste3 $v conf/londiste_db1.ini create-root node1 'dbname=db1'
 run londiste3 $v conf/londiste_db2.ini create-branch node2 'dbname=db2' --provider='dbname=db1'
 run londiste3 $v conf/londiste_db3.ini create-branch node3 'dbname=db3' --provider='dbname=db2'
 run londiste3 $v conf/londiste_db4.ini create-branch node4 'dbname=db4' --provider='dbname=db3'
-run londiste3 $v conf/londiste_db5.ini create-branch node5 'dbname=db5' --provider='dbname=db4'
+run londiste3 $v conf/londiste_db5.ini create-leaf node5 'dbname=db5' --provider='dbname=db4'
 
 msg "Run ticker"
 run pgqd $v -d conf/pgqd.ini


### PR DESCRIPTION
Hello

`londiste ... repair`  command never succeeds when it is used to check consistence between a branch and a leaf. 

Currently it
1. Pauses the branch consumer which actually acts as an external ticker for the branch queue.
2. Kinda forces a tick on the branch (reads the last tick id in fact).
3. On the leaf, waits for a tick exceeding the tick read from the branch. It never happens, as no new ticks arrive to the leaf because of no new ticks generated on the branch as the consumer is stopped.

The idea of the fix is to check the leaf for the same tick as seen on the branch, but not exceeding. Any comments welcome.

Thanks,
  Alexey
